### PR TITLE
fixed a minor bug that occured with jack4it/system-less

### DIFF
--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -167,7 +167,7 @@ class HotReloader extends Emitter {
         })
       }
 
-      if (module.importers.length === 0) {
+      if (typeof module.importers == 'undefined' || module.importers.length === 0) {
         toReimport.push(module.name)
       } else {
         let deleted = deleteAllImporters(module)

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -167,7 +167,7 @@ class HotReloader extends Emitter {
         })
       }
 
-      if (typeof module.importers == 'undefined' || module.importers.length === 0) {
+      if (typeof module.importers === 'undefined' || module.importers.length === 0) {
         toReimport.push(module.name)
       } else {
         let deleted = deleteAllImporters(module)


### PR DESCRIPTION
Just added hot reloading for less modules (see https://github.com/jack4it/system-less/pull/1) and noted, that `module.importers` might be undefined.

This patch implements a workaround for that case