### PR TITLE
Provide a default listener, warn for System.trace unset

### DIFF
--- a/default-listen-localhost.js
+++ b/default-listen-localhost.js
@@ -1,0 +1,2 @@
+import HotReloader from './hot-reloader.js';
+new HotReloader('http://localhost:5776');

--- a/default-listen-localhost.js
+++ b/default-listen-localhost.js
@@ -1,2 +1,2 @@
-import HotReloader from './hot-reloader.js';
-new HotReloader('http://localhost:5776');
+import HotReloader from './hot-reloader.js'
+HotReloader('http://localhost:5776')

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -4,6 +4,9 @@ import Emitter from 'weakee'
 import debug from 'debug'
 const d = debug('jspm-hot-reloader')
 
+if (System.trace !== true)
+  console.warn('System.trace must be set to true via configuration before loading modules to hot-reload.');
+
 function identity (value) {
   return value
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "react": "npm:react@^0.14.3",
       "react-dom": "npm:react-dom@^0.14.3",
       "react-tap-event-plugin": "npm:react-tap-event-plugin@^0.2.1"
+    },
+    "map": {
+      "./default-listen-localhost.js": {
+        "node": "@empty"
+      }
     }
   },
   "standard": {


### PR DESCRIPTION
Let me know your thoughts here. I find this useful to just have to include:

```javascript
System.import('systemjs-hot-reloader/default-listen-localhost.js').then(function() {
  System.import('app');
});
```

Or even just in app.js:

```javascript
import 'systemjs-hot-reloader/default-listen-localhost.js';
// import ...
```

(or will the second case cause timing issues?)

I'm open to alternative names, perhaps just `default-listener.js`?