### PR TITLE
Prev instance mocking

### DIFF
--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -4,8 +4,8 @@ import Emitter from 'weakee'
 import debug from 'debug'
 const d = debug('hot-reloader')
 
-const prevInstancePath = System.normalizeSync('capaj/systemjs-hot-reloader/prevInstance.js');
-d('prevInstancePath: ',prevInstancePath)
+const prevInstancePath = System.normalizeSync('capaj/systemjs-hot-reloader/prevInstance.js')
+d('prevInstancePath: ', prevInstancePath)
 
 if (System.trace !== true) {
   console.warn('System.trace must be set to true via configuration before loading modules to hot-reload.')
@@ -201,10 +201,10 @@ class HotReloader extends Emitter {
     const promises = toReimport.map((moduleName) => {
       const deletedModule = this.modulesJustDeleted[moduleName]
       if (deletedModule !== undefined) {
-        d('mocking prevInstance module');
-        System.delete(System.normalizeSync(prevInstancePath));
-        d('deletedModule.exports: ', deletedModule.exports);
-        System.set(prevInstancePath, System.newModule(deletedModule.exports));
+        d('mocking prevInstance module')
+        System.delete(System.normalizeSync(prevInstancePath))
+        d('deletedModule.exports: ', deletedModule.exports)
+        System.set(prevInstancePath, System.newModule(deletedModule.exports))
       }
       return this.originalSystemImport.call(System, moduleName).then(moduleReloaded => {
         d('reimported ', moduleName)
@@ -221,7 +221,7 @@ class HotReloader extends Emitter {
       this.modulesJustDeleted = {}
       this.failedReimport = null
       this.currentHotReload = null
-      System.delete(System.normalizeSync(prevInstancePath));
+      System.delete(System.normalizeSync(prevInstancePath))
       d('all reimported in ', new Date().getTime() - start, 'ms')
     }, (err) => {
       this.emit('error', err)

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -202,6 +202,7 @@ class HotReloader extends Emitter {
       const deletedModule = this.modulesJustDeleted[moduleName]
       if (deletedModule !== undefined) {
         d('mocking prevInstance module');
+        System.delete(System.normalizeSync(prevInstancePath));
         d('deletedModule.exports: ', deletedModule.exports);
         System.set(prevInstancePath, System.newModule(deletedModule.exports));
       }

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -4,7 +4,7 @@ import Emitter from 'weakee'
 import debug from 'debug'
 const d = debug('hot-reloader')
 
-var prevInstancePath = System.normalizeSync('capaj/systemjs-hot-reloader/prevInstance.js');
+const prevInstancePath = System.normalizeSync('capaj/systemjs-hot-reloader/prevInstance.js');
 d('prevInstancePath: ',prevInstancePath)
 
 if (System.trace !== true) {

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -4,6 +4,9 @@ import Emitter from 'weakee'
 import debug from 'debug'
 const d = debug('hot-reloader')
 
+var prevInstancePath = System.normalizeSync('capaj/systemjs-hot-reloader/prevInstance.js');
+d('prevInstancePath: ',prevInstancePath)
+
 if (System.trace !== true) {
   console.warn('System.trace must be set to true via configuration before loading modules to hot-reload.')
 }
@@ -196,10 +199,16 @@ class HotReloader extends Emitter {
   }
   reImportRootModules (toReimport, start) {
     const promises = toReimport.map((moduleName) => {
+      const deletedModule = this.modulesJustDeleted[moduleName]
+      if (deletedModule !== undefined) {
+        d('mocking prevInstance module');
+        System.delete(System.normalizeSync(prevInstancePath));
+        d('deletedModule.exports: ', deletedModule.exports);
+        System.set(prevInstancePath, System.newModule(deletedModule.exports));
+      }
       return this.originalSystemImport.call(System, moduleName).then(moduleReloaded => {
         d('reimported ', moduleName)
         if (typeof moduleReloaded.__reload === 'function') {
-          const deletedModule = this.modulesJustDeleted[moduleName]
           if (deletedModule !== undefined) {
             moduleReloaded.__reload(deletedModule.exports) // calling module reload hook
           }
@@ -212,6 +221,7 @@ class HotReloader extends Emitter {
       this.modulesJustDeleted = {}
       this.failedReimport = null
       this.currentHotReload = null
+      System.delete(System.normalizeSync(prevInstancePath));
       d('all reimported in ', new Date().getTime() - start, 'ms')
     }, (err) => {
       this.emit('error', err)

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -202,7 +202,6 @@ class HotReloader extends Emitter {
       const deletedModule = this.modulesJustDeleted[moduleName]
       if (deletedModule !== undefined) {
         d('mocking prevInstance module');
-        System.delete(System.normalizeSync(prevInstancePath));
         d('deletedModule.exports: ', deletedModule.exports);
         System.set(prevInstancePath, System.newModule(deletedModule.exports));
       }

--- a/prevInstance.js
+++ b/prevInstance.js
@@ -1,0 +1,2 @@
+export default function() {
+}

--- a/prevInstance.js
+++ b/prevInstance.js
@@ -1,2 +1,2 @@
-export default function() {
+export default function () {
 }


### PR DESCRIPTION
Alternative fix for https://github.com/capaj/systemjs-hot-reloader/issues/34. 
It temporarily creates a module that contains the previous instance of the module that's being re-imported. This is currently only the root module. 

Because I needed a placeholder I've create a prevInstance.js file in the package. I would really love a better solution. 
Another hack is that the hot-reloader.js contains the name of the package;
``` javascript
const prevInstancePath = System.normalizeSync('capaj/systemjs-hot-reloader/prevInstance.js');
```
I would prefer to do something like: 
``` javascript
const prevInstancePath = System.normalizeSync('./prevInstance.js');
```

Curious what you guys think of this solution. Ideas are welcome. 