### PR TITLE
Add capability to reload modules manually

### DIFF
--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -244,18 +244,18 @@ class HotReloader extends Emitter {
       this.currentHotReload = null
     })
   }
-  reloadAllModules({exclude, include} = {}) {
-      let toReload = Object.keys(System.loads);
+  reloadAllModules ({exclude, include} = {}) {
+    let toReload = Object.keys(System.loads)
 
-      if (exclude) {
-          toReload = toReload.filter(k => !k.match(exclude));
-      }
+    if (exclude) {
+      toReload = toReload.filter(k => !k.match(exclude))
+    }
 
-      if (include) {
-          toReload = toReload.filter(k => k.match(include));
-      }
-      
-      toReload.forEach(moduleName => this.hotReload(moduleName));
+    if (include) {
+      toReload = toReload.filter(k => k.match(include))
+    }
+
+    toReload.forEach(moduleName => this.hotReload(moduleName))
   }
 }
 

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -244,6 +244,19 @@ class HotReloader extends Emitter {
       this.currentHotReload = null
     })
   }
+  reloadAllModules({exclude, include} = {}) {
+      let toReload = Object.keys(System.loads);
+
+      if (exclude) {
+          toReload = toReload.filter(k => !k.match(exclude));
+      }
+
+      if (include) {
+          toReload = toReload.filter(k => k.match(include));
+      }
+      
+      toReload.forEach(moduleName => this.hotReload(moduleName));
+  }
 }
 
 export default HotReloader


### PR DESCRIPTION
Often when hot reloading I need to refresh the page (due to errors, for example). A function like this could help with that. 

A user can assign a key mapping to it in the browser, and reload just their modules excluding jspm_packages, or call it based on any other scenario he chooses.