### PR TITLE
find module even when module name != module address

### DIFF
--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -139,9 +139,11 @@ class HotReloader extends Emitter {
         }
         const fullModulePath = location.origin + '/' + moduleName
         const loadsKey = Object.keys(System.loads).find((n) => {
-          return n.indexOf(fullModulePath) !== -1
+          return (n.indexOf(fullModulePath) !== -1) || (System.loads[n].address.indexOf(fullModulePath) !== -1) 
         })
         // normalize does not yield a key which would match the key used in System.loads, so we have to improvise a bit
+        // also, the module name may not match the address for plugins making use of the SystemJS locate hook,
+        //    so check the address also
         if (loadsKey) {
           return System.loads[loadsKey]
         }


### PR DESCRIPTION
When a plugin makes use of the locate function to find a file, the address does not match the loader name.  I included a check for the address so that such cases can be hot reloaded.