### PR TITLE
Adding option to disable logging to the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ System.import('./app.js')
 ```
 You can drop the if statement, but it is nice and convenient to load reloader only when on localhost. That way you can go into production without changing anything.
 
+#### Debugging
+By default, systemjs-hot-reloader logs to the console what it's doing when hot reloading a module. If you want to disable logging, try the following:
+```js
+import {setDebugLogging} from 'systemjs-hot-reloader';
+
+setDebugLogging(false);
+```
+
 ## Sample projects
 
 Boilerplate set up for hot reloading modules you can fork and use with 3 simple terminal commands(git clone XXX && npm i && npm start):

--- a/hot-reloader.js
+++ b/hot-reloader.js
@@ -56,3 +56,4 @@ class HotReloader extends Emitter {
 }
 
 export default HotReloader
+export {setDebugLogging} from 'systemjs-hmr'


### PR DESCRIPTION
See https://github.com/alexisvincent/systemjs-hmr/pull/14, which is code that is waiting to be published in systemjs-hmr. **Until that is published, this pull request should not be merged**.

This simply exposes a new function `setDebugLogging` that allows the user to turn of logging things to the console. Note that when this project migrates to the [`next.js`](https://github.com/alexisvincent/systemjs-hmr/blob/master/lib/next.js) of systemjs-hmr, that this function will no longer be exported from systemjs-hmr. So potentially it would cause a breaking change for those who are using the function but then upgrade to systemjs-hmr@next.